### PR TITLE
Revised the unifying techniques section

### DIFF
--- a/content/04.network_applications.md
+++ b/content/04.network_applications.md
@@ -23,7 +23,7 @@ The output of this pipeline is an embedding space that clusters similar node typ
 Matrix factorization is a technique that uses linear algebra to map high dimensional data onto a low dimensional space.
 This projection is accomplished by decomposing a matrix into a set of small rectangular matrices (Figure {@fig:unifying_techniques_overview} (a)).
 Notable methods for matrix decomposition include Isomap [@doi:10.1126/science.290.5500.2319], Laplacian eigenmaps [@doi:10.1162/089976603321780317] and Principal Component Analysis (PCA) [@doi:10/bm8dnf]/Singular Vector Decomposition (SVD) [@doi:10.1007/BF02288367].
-These methods were designed to be used on many different types of data; however, we discus their use in the context of representing a knowledge graphs in a low dimensional space.	
+These methods were designed to be used on many different types of data; however, we discuss their use in the context of representing a knowledge graphs in a low dimensional space.	
 
 SVD [@doi:10.1007/BF02288367] is an algorithm that uses matrix factorization to portray knowledge graphs in a low dimensional space.
 The input for this algorithm is an adjacency matrix ($A$), which is a square matrix where rows and columns represent nodes and each entry represents the presence of an edge between two nodes. 

--- a/content/04.network_applications.md
+++ b/content/04.network_applications.md
@@ -3,100 +3,98 @@
 Knowledge graphs can help researchers tackle many biomedical tasks such as finding new treatments for existing drugs [@doi:10.7554/eLife.26726], aiding efforts to diagnose patients [@arxiv:1611.07012] and predicting associations between diseases and biomolecules [@doi:10.1155/2017/2498957].
 In many cases, solutions rely on representing knowledges graphs in a low dimensional space, which is a process called representation learning.
 This space preserves a knowledge graph's local and/or global structure and can support efforts to apply machine learning methods to make predictions.
-We discuss the unifying techniques to construct this low dimensional space and unifying applications that use this space to solve biomedical problems.
+In the next few sections we discuss the unifying techniques that construct this low dimensional space and unifying applications that use this space to solve biomedical problems.
 
 ### Unifying Techniques
 
-Mapping high dimensional data into a low dimensional space has greatly improved modeling performance in fields such as natural language processing [@arxiv:1301.3781; @arxiv:1310.4546] and image analysis [@arxiv:1512.03385].
-The success of these approaches provides rationale for projecting knowledge graphs into a low dimensional space as well [@arxiv:1709.05584].
-Techniques that perform this projection often require information on how nodes are connected with one another [@raw:gongreplearn; @doi:10.1109/TKDE.2016.2606098; @raw:hanreplearn; @doi:10.1145/2806416.2806512], while other approaches can work directly with the edges themselves [@arxiv:1610.04073].
-We group methods for producing low-dimensional representations of knowledge graphs into the following three categories: matrix factorization, translational methods, and deep learning (Figure {@fig:unifying_techniques_overview}).
+Mapping high dimensional data into a low dimensional space greatly improves modeling performance in fields such as natural language processing [@arxiv:1301.3781; @arxiv:1310.4546] and image analysis [@arxiv:1512.03385].
+The success of these approaches provides rationale for representing knowledge graphs into a low dimensional space [@arxiv:1709.05584].
+Techniques that construct this representation often require information on how nodes are connected with one another [@raw:gongreplearn; @doi:10.1109/TKDE.2016.2606098; @raw:hanreplearn; @doi:10.1145/2806416.2806512], while other approaches can work directly with the edges themselves [@arxiv:1610.04073].
+We group these methods into the following three categories: matrix factorization, translational methods, and deep learning (Figure {@fig:unifying_techniques_overview}).
 
 ![
-Pipeline for embedding knowledge graphs into a low dimensional space.
-Starting with a knowledge graph, embeddings can be generated using one of the following options: Matrix Factorization (a), Translational Models (b) or Deep Learning (c).
+Pipeline for representing knowledge graphs in a low dimensional space.
+Starting with a knowledge graph, this space can be generated using one of the following options: Matrix Factorization (a), Translational Models (b) or Deep Learning (c).
 The output of this pipeline is an embedding space that clusters similar node types together.
 ](images/figures/unifying_techniques_overview.png){#fig:unifying_techniques_overview}
 
 #### Matrix Factorization
 
-Matrix factorization is a technique that uses linear algebra to map high dimensional data into a low dimensional space.
+Matrix factorization is a technique that uses linear algebra to map high dimensional data onto a low dimensional space.
 This projection is accomplished by decomposing a matrix into a set of small rectangular matrices (Figure {@fig:unifying_techniques_overview} (a)).
 Notable methods for matrix decomposition include Isomap [@doi:10.1126/science.290.5500.2319], Laplacian eigenmaps [@doi:10.1162/089976603321780317] and Principal Component Analysis (PCA) [@doi:10/bm8dnf]/Singular Vector Decomposition (SVD) [@doi:10.1007/BF02288367].
-These methods were designed to be used on many different types of data; however, we discuss their use in the context of projecting knowledge graphs into a low dimensional space.	
+These methods were designed to be used on many different types of data; however, we focus on using them in the context of representing a knowledge graphs in a low dimensional space.	
 
-SVD [@doi:10.1007/BF02288367] is an algorithm that uses matrix factorization to represent knowledge graphs in a low dimensional space.
+SVD [@doi:10.1007/BF02288367] is an algorithm that uses matrix factorization to portray knowledge graphs in a low dimensional space.
 The input for this algorithm is an adjacency matrix ($A$), which is a square matrix where rows and columns represent nodes and each entry represents the presence of an edge between two nodes. 
-This adjacency matrix ($A$) gets decomposed into three parts: a square matrix $Σ$ and a set of two small rectangular matrices $U$ and $V^{T}$.
-This values within $Σ$ are called singular values, which akin to eigenvalues [@doi:10.1007/BF02288367].
-Each row in $U$ and each column in $V^{T}$ represents nodes projected onto a low dimensional space [@doi:10.1007/BF02288367; @doi:10/bm8dnf].
+This matrix ($A$) gets decomposed into three parts: a square matrix $Σ$ and a set of two small rectangular matrices $U$ and $V^{T}$.
+This values within $Σ$ are called singular values, which are akin to eigenvalues [@doi:10.1007/BF02288367].
+Each row in $U$ and each column in $V^{T}$ represents nodes within a low dimensional space [@doi:10.1007/BF02288367; @doi:10/bm8dnf].
 In practice $U$ is usually used to represent nodes in a knowledge graph, but $V^{T}$ can also be used [@doi:10.1007/BF02288367; @raw:Jiezhon2018].
-Typically, SVD appears in recommendation systems via collaborative filtering [@doi:10.1155/2009/421425]; however, this technique can also be used as a standalone baseline to compare to other approaches [@arxiv:1906.05017].
+Typically, SVD appears in recommendation systems via collaborative filtering [@doi:10.1155/2009/421425]; however, this technique can also be used as a standalone baseline to compare to other methods [@arxiv:1906.05017].
 
-Laplacian eigenmaps assume there is low dimensional structure in a high dimensional space [@doi:10.1162/089976603321780317].
+Laplacian eigenmaps is a technique that assumes there is low dimensional structure in a high dimensional space [@doi:10.1162/089976603321780317].
 This algorithm preserves this structure while projecting data into a low dimensional space. 
-Typically, the first step of this algorithm is to construct a figurative knowledge graph where nodes represent datapoints and edges are constructed based on similarity of two datapoints; however, in this context, the knowledge graph has already been constructed.
+Typically, the first step of this algorithm is to construct a figurative knowledge graph where nodes represent datapoints and edges are constructed based on similarity of two datapoints; however, in this context, the knowledge graph has already been defined.
 The next step in this algorithm is to obtain both an adjacency matrix ($A$) and a degree matrix ($D$) from the knowledge graph.
 A degree matrix is a diagonal matrix where each entry represents the number of edges connected to a node.
 The adjacency and degree matrices are converted into a laplacian matrix ($L$), which is a matrix that shares the same properties as the adjacency matrix.
-The laplacian matrix is generated by subtracting the adjacency matrix from the degree matrix ($L=D-A$) and, once constructed, the algorithm uses linear algebra to calculate eigenvalues and eigenvectors from the matrix ($Lx = \lambda Dx$).
-The generated eigenvectors represent the knowledge graph's nodes projected onto a low dimensional space [@doi:10.1162/089976603321780317].
-A number of approaches have used variants of this algorithm to perform their own node projection [@raw:gongreplearn; @doi:10.1109/TKDE.2016.2606098; @arxiv:1905.09763].
+The laplacian matrix is generated by subtracting the adjacency matrix from the degree matrix ($L=D-A$) and, once constructed, the algorithm uses linear algebra to calculate the laplacian's eigenvalues and eigenvectors ($Lx = \lambda Dx$).
+The generated eigenvectors represent the knowledge graph's nodes represented in a low dimensional space [@doi:10.1162/089976603321780317].
+Other efforts have used variants of this algorithm to construct their own low dimensional representations of knowledge graphs [@raw:gongreplearn; @doi:10.1109/TKDE.2016.2606098; @arxiv:1905.09763].
 Typically, eigenmaps work well when knowledge graphs have a sparse number of edges between nodes but struggle when presented with denser networks [@arxiv:1906.05017; @doi:10.1371/journal.pcbi.1005621; @arxiv:1905.09763].
-A future direction is to adapt these methods to scale to knowledge graphs that have a large number of edges.
+An open area of exploration is to adapt these methods to accommodate knowledge graphs that have a large number of edges.
 
 Matrix factorization is a powerful technique that uses a matrices such as  an adjacency matrix as input.
-Common approaches involve using SVD, Laplacian eigenmaps or variants of the two to perform embeddings.
-Despite reported success, the dependence on matrices like an adjacency matrix creates an issue of scalability as matrices of large networks would take too much memory for a regular computer to handle.
-Furthermore, these methods treat all edge types the same, but a possible extension for future approaches that use matrix factorization would be to incorporate node and edge types as sources of input.
+Common approaches involve using SVD, Laplacian eigenmaps or variants of the two to construct low dimensional representations.
+Despite reported success, the dependence on matrices like an adjacency matrix creates an issue of scalability as matrices of large networks would take too much memory for a regular computer to operate well.
+Furthermore, these methods treat all edge types the same, but a possible extension is to incorporate node and edge types as sources of input.
 
 #### Translational Distance Models
 
 Translational distance models treat edges in a knowledge graph as linear transformations.
-As an example, one such algorithm, TransE [@raw:bordestranse], treats every node-edge pair as a triplet with head nodes represented as $\textbf{h}$, edges represented as $\textbf{r}$, and tail nodes represented as $\textbf{t}$.
-These representations are combined into an equation that mimics the iconic word vectors translations ($\textbf{king} - \textbf{man} + \textbf{woman} \approx \textbf{queen}$) from the Word2vec model [@arxiv:1310.4546].
-The equation is shown as follows: $\textbf{h} + \textbf{r} \approx \textbf{t}$.
+For example, one such algorithm, TransE [@raw:bordestranse], treats every node-edge pair as a triplet with head nodes represented as $\textbf{h}$, edges represented as $\textbf{r}$, and tail nodes represented as $\textbf{t}$.
+These representations are combined into an equation that mimics the iconic word vectors translations ($\textbf{king} - \textbf{man} + \textbf{woman} \approx \textbf{queen}$) from the word2vec model [@arxiv:1310.4546].
+The described equation is shown as follows: $\textbf{h} + \textbf{r} \approx \textbf{t}$.
 Starting at the head node ($\textbf{h}$), add the edge vector ($\textbf{r}$) and the result should be the tail node ($\textbf{t}$).
-TransE optimizes embeddings for $\textbf{h}$, $\textbf{r}$, $\textbf{t}$, while guaranteeing the global equation ($\textbf{h} + \textbf{r} \approx \textbf{t}$) is satisfied [@raw:bordestranse].
-A caveat to the TransE approach is that it the training steps force relationships to have a one to one mapping, which may not be appropriate for all types of relationships.
+TransE optimizes vectors for $\textbf{h}$, $\textbf{r}$, $\textbf{t}$, while guaranteeing the global equation ($\textbf{h} + \textbf{r} \approx \textbf{t}$) is satisfied [@raw:bordestranse].
+A caveat to the TransE approach is that it the training steps force relationships to have a one to one mapping, which may not be appropriate for all relationship types.
 
-Wang et al. [@raw:wangtransH] attempted to resolve the one to one mapping issue by developing the TransH model.
-TransH treats relations as hyperplanes rather than a regular vector and projects the head ($\textbf{h}$) and tail ($\textbf{t}$) nodes onto the hyperplane.
+Wang et al., attempted to resolve the one to one mapping issue by developing the TransH model [@raw:wangtransH].
+TransH treats relations as hyperplanes rather than a regular vector and projects the head ($\textbf{h}$) and tail ($\textbf{t}$) nodes onto this hyperplane.
 Following this projection, a distance vector ($\textbf{d}_{r}$) is calculated between the projected head and tail nodes.
-Finally, each vector is optimized while preserving the global equation ($\textbf{h} + \textbf{d}_{r} \approx \textbf{t}$) [@raw:wangtransH].
-Other approaches [@raw:lintransR, @arxiv:1610.04073; @arxiv:1909.00672] have built off of the TransE and TransH models. 
-In the future, it may be beneficial for these models is to incorporate other types of information such as edge confidence scores, textual information, or edge type information when optimizing these embeddings.
+Finally, each vector is optimized while preserving the global equation: $\textbf{h} + \textbf{d}_{r} \approx \textbf{t}$ [@raw:wangtransH].
+Other effots have built off of the TransE and TransH models [@raw:lintransR, @arxiv:1610.04073; @arxiv:1909.00672]. 
+In the future, it may be beneficial for these models is to incorporate other types of information such as edge confidence scores, textual information, or edge type information when optimizing these vectors.
 
 #### Deep Learning
 
 Deep learning is a paradigm that uses multiple non-linear transformations to map high dimensional data into a low dimensional space.
-Many techniques that use deep learning for knowledge graphs are based on word2vec [@arxiv:1310.4546; @arxiv:1301.3781], a set of approaches that are widely used for natural language processing.
-The goal of word2vec is to project words into a low dimensional space that preserves their semantic meaning.
+Many techniques that use deep learning on knowledge graphs are based on word2vec [@arxiv:1310.4546; @arxiv:1301.3781], a set of approaches that are widely used for natural language processing.
+The goal of word2vec is to project words onto a low dimensional space that preserves their semantic meaning.
 Strategies for training word2vec models use one of two neural network architectures: skip-gram and continuous bag of words (CBOW).
-Both models are feed-forward neural networks, but CBOW models are trained to predict a word given it's context while skip-gram models are trained to predict the context given a word [@arxiv:1310.4546; @arxiv:1301.3781].
+Both models are feed-forward neural networks, but CBOW models are trained to predict a word given its context while skip-gram models are trained to predict the context given a word [@arxiv:1310.4546; @arxiv:1301.3781].
 Once training has finished, words are now associated with dense vectors that downstream models, such as feed forward networks or recurrent networks, can use for input.
 
-Deepwalk [@arxiv:1403.6652] is an early method designed to project a knowledge graph into a low dimensional space. 
+Deepwalk is an early method that represents knowledge graphs in a low dimensional space [@arxiv:1403.6652]. 
 The first step of this method is to perform a random walk along a knowledge graph.
-During the random walk, every generated sequence of nodes is recorded and treated like a sentence in word2vec [@arxiv:1310.4546; @arxiv:1301.3781].
-After every node has been processed, a skip-gram model is trained to predict the context of each node thereby projecting a knowledge graph into a low dimensional space [@arxiv:1403.6652].
-A limitation of this method is that the random walk cannot be controlled, so every node has an equal chance to be reached.
-Grover and Leskovec [@arxiv:1607.00653] demonstrated that this limitation can hurt performance when classifying edges between nodes and developed node2vec as a result.
-Node2vec [@arxiv:1607.00653] operates the in the same fashion as deepwalk; however, this algorithm specifies a parameter that lets the random walk be biased when traversing nodes.
-A caveat to both deepwalk and node2vec is that both algorithms ignore information such as edge type and node type.
-Various approaches have evolved to fix this limitation by incorporating  node, edge and even path types when projecting nodes into a low dimensional space [@arxiv:1704.03165; @doi:10.1145/3097983.3098036; @arxiv:1809.02269; @arxiv:1808.05611].
-These approaches primarily capture a network's local structure. 
-An emerging area of work is to develop approaches that capture both the local and global structure of a network when projecting knowledge graphs into a low dimensional space.
+During the random walk, every generated sequence of nodes is recorded and treated exactly similar to a sentence in word2vec [@arxiv:1310.4546; @arxiv:1301.3781].
+After every node has been processed, a skip-gram model is trained to predict the context of each node thereby constructing a low dimensional representation of a knowledge graph [@arxiv:1403.6652].
+A limitation for deepwalk is that the random walk cannot be controlled, so every node has an equal chance to be reached.
+Grover and Leskovec demonstrated that this limitation can hurt performance when classifying edges between nodes and developed node2vec as a result [@arxiv:1607.00653].
+Node2vec operates the in the same fashion as deepwalk; however, this algorithm specifies a parameter that lets the random walk be biased when traversing nodes [@arxiv:1607.00653].
+A caveat to both deepwalk and node2vec is that they ignore information such as edge type and node type.
+Various approaches have evolved to fix this limitation by incorporating  node, edge and even path types when representing knowledge graphs in a low dimensional space [@arxiv:1704.03165; @doi:10.1145/3097983.3098036; @arxiv:1809.02269; @arxiv:1808.05611].
+An emerging area of work is to develop approaches that capture both the local and global structure of a graph when constructing this low dimensional space.
 
-Some deep learning approaches use an adjacency matrix as input [@arxiv:1310.4546; @arxiv:1301.3781] instead of using the word2vec framing.
-Algorithms such as auto-encoders can also generate network embeddings [@arxiv:1802.08352; @arxiv:1611.07308; @arxiv:1802.04407].
-Autoencoders [@arxiv:1404.7828; @raw:Baldi2011] are neural networks that map input such as an adjacency matrices into a low dimensional space and then learns how to construct this space by reconstructing the same input.
-The generated low dimensional space captures the node connectivity structure of the knowledge graph and every node is mapped onto this space [@arxiv:1802.08352; @arxiv:1611.07308; @arxiv:1802.04407].
-Despite the high potential of this approach, this method relies on an adjacency matrix for input.
-If a knowledge graph asymptotically increases in size, these approaches could run into scalability issues as discovered by Khosla et al. [@arxiv:1903.07902].
-Plus, Khosla et al.[@arxiv:1903.07902] discovered that approaches akin to node2vec outperformed algorithms using autoencoders when undergoing link prediction and node classification.
-Overall, the performance of these models largely depends upon the structure of nodes and edges within a knowledge graph [@arxiv:1903.07902].
-Future approaches should consider creating hybrid models that use both node2vec and autoencoders to construct complementary low dimensional representations of knowledge graphs.
+Instead of using the word2vec framework, some deep learning approaches use an adjacency matrix as input [@arxiv:1310.4546; @arxiv:1301.3781].
+These approaches use neural networks called autoencoders to generate this low dimensional space [@arxiv:1802.08352; @arxiv:1611.07308; @arxiv:1802.04407].
+Autoencoders map input such as an adjacency matrices into a low dimensional space and then determines how to construct this space via reconstructing the same input [@arxiv:1404.7828; @raw:Baldi2011].
+This generated space represents the nodes and their connectivity structure within a knowledge graph [@arxiv:1802.08352; @arxiv:1611.07308; @arxiv:1802.04407].
+Despite the high potential of this approach, this method relies on an adjacency matrix for input which can run into scalability issues as a knowledge graph asymptotically increases in size [@arxiv:1903.07902].
+Plus, Khosla et al., discovered that approaches akin to node2vec outperformed algorithms using autoencoders when undergoing link prediction and node classification [@arxiv:1903.07902].
+Overall, the performance of deep learning techniques largely depends upon the structure of nodes and edges within a knowledge graph [@arxiv:1903.07902].
+Future efforts should consider creating hybrid models that use both node2vec and autoencoders to construct complementary low dimensional representations of knowledge graphs.
 
 ### Unifying Applications
 

--- a/content/04.network_applications.md
+++ b/content/04.network_applications.md
@@ -3,7 +3,7 @@
 Knowledge graphs can help researchers tackle many biomedical tasks such as finding new treatments for existing drugs [@doi:10.7554/eLife.26726], aiding efforts to diagnose patients [@arxiv:1611.07012] and predicting associations between diseases and biomolecules [@doi:10.1155/2017/2498957].
 In many cases, solutions rely on representing knowledges graphs in a low dimensional space, which is a process called representation learning.
 This space preserves a knowledge graph's local and/or global structure and can support efforts to apply machine learning methods to make predictions.
-In the next few sections we discuss the unifying techniques that construct this low dimensional space and unifying applications that use this space to solve biomedical problems.
+In the next sections we review the unifying techniques that construct this low dimensional space and unifying applications that use this space to solve biomedical problems.
 
 ### Unifying Techniques
 
@@ -23,7 +23,7 @@ The output of this pipeline is an embedding space that clusters similar node typ
 Matrix factorization is a technique that uses linear algebra to map high dimensional data onto a low dimensional space.
 This projection is accomplished by decomposing a matrix into a set of small rectangular matrices (Figure {@fig:unifying_techniques_overview} (a)).
 Notable methods for matrix decomposition include Isomap [@doi:10.1126/science.290.5500.2319], Laplacian eigenmaps [@doi:10.1162/089976603321780317] and Principal Component Analysis (PCA) [@doi:10/bm8dnf]/Singular Vector Decomposition (SVD) [@doi:10.1007/BF02288367].
-These methods were designed to be used on many different types of data; however, we focus on using them in the context of representing a knowledge graphs in a low dimensional space.	
+These methods were designed to be used on many different types of data; however, we discus their use in the context of representing a knowledge graphs in a low dimensional space.	
 
 SVD [@doi:10.1007/BF02288367] is an algorithm that uses matrix factorization to portray knowledge graphs in a low dimensional space.
 The input for this algorithm is an adjacency matrix ($A$), which is a square matrix where rows and columns represent nodes and each entry represents the presence of an edge between two nodes. 
@@ -60,7 +60,7 @@ Starting at the head node ($\textbf{h}$), add the edge vector ($\textbf{r}$) and
 TransE optimizes vectors for $\textbf{h}$, $\textbf{r}$, $\textbf{t}$, while guaranteeing the global equation ($\textbf{h} + \textbf{r} \approx \textbf{t}$) is satisfied [@raw:bordestranse].
 A caveat to the TransE approach is that it the training steps force relationships to have a one to one mapping, which may not be appropriate for all relationship types.
 
-Wang et al., attempted to resolve the one to one mapping issue by developing the TransH model [@raw:wangtransH].
+Wang et al. attempted to resolve the one to one mapping issue by developing the TransH model [@raw:wangtransH].
 TransH treats relations as hyperplanes rather than a regular vector and projects the head ($\textbf{h}$) and tail ($\textbf{t}$) nodes onto this hyperplane.
 Following this projection, a distance vector ($\textbf{d}_{r}$) is calculated between the projected head and tail nodes.
 Finally, each vector is optimized while preserving the global equation: $\textbf{h} + \textbf{d}_{r} \approx \textbf{t}$ [@raw:wangtransH].
@@ -78,7 +78,7 @@ Once training has finished, words are now associated with dense vectors that dow
 
 Deepwalk is an early method that represents knowledge graphs in a low dimensional space [@arxiv:1403.6652]. 
 The first step of this method is to perform a random walk along a knowledge graph.
-During the random walk, every generated sequence of nodes is recorded and treated exactly similar to a sentence in word2vec [@arxiv:1310.4546; @arxiv:1301.3781].
+During the random walk, every generated sequence of nodes is recorded and treated as a sentence in word2vec [@arxiv:1310.4546; @arxiv:1301.3781].
 After every node has been processed, a skip-gram model is trained to predict the context of each node thereby constructing a low dimensional representation of a knowledge graph [@arxiv:1403.6652].
 A limitation for deepwalk is that the random walk cannot be controlled, so every node has an equal chance to be reached.
 Grover and Leskovec demonstrated that this limitation can hurt performance when classifying edges between nodes and developed node2vec as a result [@arxiv:1607.00653].
@@ -94,7 +94,7 @@ This generated space represents the nodes and their connectivity structure withi
 Despite the high potential of this approach, this method relies on an adjacency matrix for input which can run into scalability issues as a knowledge graph asymptotically increases in size [@arxiv:1903.07902].
 Plus, Khosla et al., discovered that approaches akin to node2vec outperformed algorithms using autoencoders when undergoing link prediction and node classification [@arxiv:1903.07902].
 Overall, the performance of deep learning techniques largely depends upon the structure of nodes and edges within a knowledge graph [@arxiv:1903.07902].
-Future efforts should consider creating hybrid models that use both node2vec and autoencoders to construct complementary low dimensional representations of knowledge graphs.
+Future work should include hybrid models that use both node2vec and autoencoders to construct complementary low dimensional representations of knowledge graphs.
 
 ### Unifying Applications
 


### PR DESCRIPTION
I revised the unifying techniques section to improve flow and keep consistent terminology.
Note I may have added commas with "author et al." clauses. I can remove if they are unnecessary.