### PR TITLE
Enable manubot docx building

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,10 @@ script:
 cache:
   directories:
     - ci/cache
+
+env:
+  - BUILD_DOCX=true
+  
 deploy:
   provider: script
   script: bash -o xtrace ci/deploy.sh


### PR DESCRIPTION
If I read the [documents](https://github.com/greenelab/knowledge-graph-review/tree/master/build) correctly, this PR should enable manubot to build word docx files. This will be important if/when the journal reviewers want an editable file.